### PR TITLE
Set SDK version in Version.plist

### DIFF
--- a/Sources/ApptentiveKit/Resources/Version.plist
+++ b/Sources/ApptentiveKit/Resources/Version.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>$(APPTENTIVE_VERSION)</string>
+	<string>6.0.2</string>
 </dict>
 </plist>


### PR DESCRIPTION
This fixes Issue #13

set CFBundleShortVersionString = 6.0.2 in Version.plist

This would need to be updated for every release and should probably be automated in some way.